### PR TITLE
Use recursive $(MAKE). Fixes compatibility issues with non-GNU toolchains (BSD systems).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ CHAPTER_OBJS = $(foreach file, $(CHAPTERS), $(file).dvi)
 all: $(BOOK).pdf
 
 %.dvi : %.tex
-	make -C $(@D) tex
+	$(MAKE) -C $(@D) tex
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 index:
 	makeindex $(BOOK)

--- a/datastruct/elementary/queue/Makefile
+++ b/datastruct/elementary/queue/Makefile
@@ -8,19 +8,19 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 tool:
-	make tool -C src
+	$(MAKE) tool -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/elementary/sequence/Makefile
+++ b/datastruct/elementary/sequence/Makefile
@@ -8,19 +8,19 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 tool:
-	make tool -C src
+	$(MAKE) tool -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/heap/binary-heap/Makefile
+++ b/datastruct/heap/binary-heap/Makefile
@@ -8,16 +8,16 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/heap/other-heaps/Makefile
+++ b/datastruct/heap/other-heaps/Makefile
@@ -8,19 +8,19 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 tool:
-	make tool -C src
+	$(MAKE) tool -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/tree/AVL-tree/Makefile
+++ b/datastruct/tree/AVL-tree/Makefile
@@ -8,13 +8,13 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/tree/B-tree/Makefile
+++ b/datastruct/tree/B-tree/Makefile
@@ -8,16 +8,16 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/tree/binary-search-tree/Makefile
+++ b/datastruct/tree/binary-search-tree/Makefile
@@ -8,16 +8,16 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/tree/red-black-tree/Makefile
+++ b/datastruct/tree/red-black-tree/Makefile
@@ -8,13 +8,13 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/tree/suffix-tree/Makefile
+++ b/datastruct/tree/suffix-tree/Makefile
@@ -8,16 +8,16 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/datastruct/tree/trie/Makefile
+++ b/datastruct/tree/trie/Makefile
@@ -8,16 +8,16 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/others/appendix/list/Makefile
+++ b/others/appendix/list/Makefile
@@ -9,19 +9,19 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 tool:
-	make tool -C src
+	$(MAKE) tool -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/others/preface/Makefile
+++ b/others/preface/Makefile
@@ -8,19 +8,19 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 tool:
-	make tool -C src
+	$(MAKE) tool -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/search/Makefile
+++ b/search/Makefile
@@ -8,7 +8,7 @@ TEX = latex
 all: pdf
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/sorting/dc-sort/Makefile
+++ b/sorting/dc-sort/Makefile
@@ -8,16 +8,16 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/sorting/insertion-sort/Makefile
+++ b/sorting/insertion-sort/Makefile
@@ -8,16 +8,16 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)

--- a/sorting/select-sort/Makefile
+++ b/sorting/select-sort/Makefile
@@ -8,16 +8,16 @@ TEX = latex
 all: pdf
 
 cpp:
-	make cpp -C src
+	$(MAKE) cpp -C src
 
 c:
-	make c -C src
+	$(MAKE) c -C src
 
 haskell:
-	make haskell -C src
+	$(MAKE) haskell -C src
 
 image:
-	make -C img
+	$(MAKE) -C img
 
 pdf: $(OBJECT).dvi
 	dvipdfmx $(OBJECT)


### PR DESCRIPTION
By default, FreeBSD uses the it's own `MAKE(1)`. We can install GNU Make via `pkg install gmake` and use `gmake` to build GNU `Makefile`s.

The AlgoXY project uses recursive `make` commands. For this, it's best practice to use `$(MAKE)`. This fixes the issue with compiling on BSD systems with gmake, as well improve portability all around.

https://www.gnu.org/software/make/manual/html_node/Recursion.html
