### PR TITLE
Fix an error in build-heap section.

### DIFF
--- a/datastruct/heap/binary-heap/bheap-en.tex
+++ b/datastruct/heap/binary-heap/bheap-en.tex
@@ -266,7 +266,7 @@ $1, 2, 4, 8, ..., 2^i, ...$.
 
 The only exception is the last level. Since the tree may not full
 (note that complete binary tree doesn't mean full binary tree), the
-last level contains at most $2^{p-1}$ nodes, where $2^p \leq n$ and $n$
+last level contains at most $2^{p-1}$ nodes, where $2^p + 1 \leq n$ and $n$
 is the length of the array.
 
 The \textproc{Heapify} algorithm doesn't have any effect on leave node.


### PR DESCRIPTION
If the last level of a complete binary tree can contain at most $2^{p - 1}$
nodes, then the total nodes of the binary tree is

\[
\sum_{i = 0}^{p - 1} 2^{i} = 2^{p} - 1
\]

So it should be $2^{p} - 1 \leq n$ instead of $2^{p} \leq n$.

An example:

```
     7
   /   \
  6     5
 / \   / \
4   3 2   1
```

This binary has 7 nodes, the last level has 4 nodes, so $p = 3$, and $n
= 7$, it should be $2^3 - 1 \leq 7$ instead of $2^3 \leq 7$.