### PR TITLE
Fix a code error in appendix.

### DIFF
--- a/others/appendix/list/list-en.tex
+++ b/others/appendix/list/list-en.tex
@@ -2513,7 +2513,7 @@ to Haskell gives the following example program.
 \lstset{language=Haskell}
 \begin{lstlisting}
 span _ [] = ([], [])
-span p xs@(x:xs') = if p x then let (as, bs) = span xs' in (x:as, bs) else ([], xs)
+span p xs@(x:xs') = if p x then let (as, bs) = span p xs' in (x:as, bs) else ([], xs)
 
 break p = span (not . p)
 \end{lstlisting}


### PR DESCRIPTION
`span` is a function with two parameters, and it should be called with
two parameters in a `let`.