### PR TITLE
Fix a code error in appendix.

### DIFF
--- a/others/appendix/list/list-zh-cn.tex
+++ b/others/appendix/list/list-zh-cn.tex
@@ -2179,7 +2179,7 @@ break(p, L) =  \left \{
 \lstset{language=Haskell}
 \begin{lstlisting}[style=Haskell]
 span _ [] = ([], [])
-span p xs@(x:xs') = if p x then let (as, bs) = span xs' in (x:as, bs) else ([], xs)
+span p xs@(x:xs') = if p x then let (as, bs) = span p xs' in (x:as, bs) else ([], xs)
 
 break p = span (not . p)
 \end{lstlisting}


### PR DESCRIPTION
`span` is a function with two parameters, and it should be called with
two parameters in a `let`.